### PR TITLE
Fixed switching pages when clicking on a different animal.

### DIFF
--- a/src/components/layout/NavigationBar.js
+++ b/src/components/layout/NavigationBar.js
@@ -13,7 +13,7 @@ const PetTypes = ({ types }) => {
           <NavDropdown.Item
             key={i}
             as={Link}
-            to={`pets/${type.name.toLowerCase()}`}
+            to={`/pets/${type.name.toLowerCase()}`}
           >
             {type.name}
           </NavDropdown.Item>


### PR DESCRIPTION
The navigation link needed a forward slash at the beginning, otherwise it just adds it towards the end of the link.