### PR TITLE
Added resources page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import PetType from "./components/pets/PetType";
 import PetInfo from "./components/pets/PetInfo";
 import Footer from "./components/layout/Footer";
 import About from "./components/about/About";
+import Resources from "./components/resources/Resources"
 
 export default function App() {
   const [token, setToken] = useState("");
@@ -56,6 +57,9 @@ export default function App() {
             </Route>
             <Route path="/about">
               <About />
+            </Route>
+            <Route path="/resources">
+              <Resources />
             </Route>
             <Route path="/">
               <Home />

--- a/src/components/layout/NavigationBar.js
+++ b/src/components/layout/NavigationBar.js
@@ -76,6 +76,9 @@ export default function NavigationBar({ token }) {
           <Nav.Link as={Link} to="/about">
             About
           </Nav.Link>
+          <Nav.Link as={Link} to="/resources">
+            Resources
+          </Nav.Link>
         </Nav>
       </Navbar.Collapse>
     </Navbar>

--- a/src/components/resources/Resources.js
+++ b/src/components/resources/Resources.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
+import "./resources.css";
+export default function Home() {
+  return (
+    <div className="resources__container">
+      <h1>Adopting Pets</h1>
+      <p>
+        Adopting pets is a much more humane way to find your familys newest best friend. Every year around 6.5 million companion pets enter shelters in just the USA, and thats only dogs and cats.
+        Out of those <b>6.5 million</b>, only <b>3.2 million</b> are adopted and <b>1.5 million</b> are euthanized (Statistics provided by <a href="https://www.aspca.org/animal-homelessness/shelter-intake-and-surrender/pet-statistics">ASPCA</a>).
+        <br/><b>This leaves 1.8 million pets that go untouched each year.</b><br/><br/>
+        Adopting a pet is cheaper than buying a pet, and you also potentially save a life by doing so. Many shelter pets are already house-trained and are used to living with humans.<br/><br/>
+        <b>More information about adopting pets can be found at the links below</b><br/>
+        <Button href="https://www.petfinder.com/pet-adoption-2/pet-adoption-information/" variant="primary">
+            Pet Finder
+        </Button>
+        <Button href="https://www.humanesociety.org/resources/top-reasons-adopt-pet" variant="primary">
+            Humane Society
+        </Button>
+        <Button href="https://www.petcarehospital.net/blog/adopting-instead-of-buying-a-pet" variant="primary">
+            Petcare Hospital
+        </Button>
+      </p>
+      <br/>
+      <h1>Covid-19</h1>
+      <p>
+        Covid-19 is a newly found infectious disease that belongs to the Coronavirus family. The virus causes a respiratory infection which to some people is a minor problem, but to others could be
+        very deadly depending on many different factors. The World Health Organization has annouced that Covid-19 is considered a pandemic. Many countries have issued stay at home orders or recommendations to quarantine and self isolate.
+        <br/><br/>
+        Because people find it hard to stay at home alone, <a href="https://apnews.com/article/31e3e60e7ea6bc4566b0ee3998ab98a6">a lot of people decided to adopt a friend</a>.
+        <br/><br/>
+        <b>Pawternity Hub wants to help you stay safe and help you find a friend that can keep you company during the pandemic<br/> Check out the links below for more information about adoption during Covid-19</b>
+        <br/>
+        <Button href="https://www.petfinder.com/helping-pets/covid-19-resources/how-to-adopt-a-pet-during-covid-19/" variant="primary">
+            Pet Finder (Adopting during Covid-19)
+        </Button>
+        <Button href="https://www.oie.int/scientific-expertise/specific-information-and-recommendations/questions-and-answers-on-2019novel-coronavirus/" variant="primary">
+            World Organization for Animal Health
+        </Button>
+      </p>
+      <br/>
+      <h2>Adopt a Buddy Today!</h2>
+      <Button as={Link} to="/pets" variant="primary">
+        Adopt
+      </Button>
+    </div>
+  );
+}

--- a/src/components/resources/Resources.js
+++ b/src/components/resources/Resources.js
@@ -8,7 +8,7 @@ export default function Home() {
       <h1>Adopting Pets</h1>
       <p>
         Adopting pets is a much more humane way to find your familys newest best friend. Every year around 6.5 million companion pets enter shelters in just the USA, and thats only dogs and cats.
-        Out of those <b>6.5 million</b>, only <b>3.2 million</b> are adopted and <b>1.5 million</b> are euthanized (Statistics provided by <a href="https://www.aspca.org/animal-homelessness/shelter-intake-and-surrender/pet-statistics">ASPCA</a>).
+        Out of those <b>6.5 million</b>, only <b>3.2 million</b> are adopted and <b>1.5 million</b> are euthanized (Statistics provided by <a target="_blank" rel="noreferrer" href="https://www.aspca.org/animal-homelessness/shelter-intake-and-surrender/pet-statistics">ASPCA</a>).
         <br/><b>This leaves 1.8 million pets that go untouched each year.</b><br/><br/>
         Adopting a pet is cheaper than buying a pet, and you also potentially save a life by doing so. Many shelter pets are already house-trained and are used to living with humans.<br/><br/>
         <b>More information about adopting pets can be found at the links below</b><br/>
@@ -28,7 +28,7 @@ export default function Home() {
         Covid-19 is a newly found infectious disease that belongs to the Coronavirus family. The virus causes a respiratory infection which to some people is a minor problem, but to others could be
         very deadly depending on many different factors. The World Health Organization has annouced that Covid-19 is considered a pandemic. Many countries have issued stay at home orders or recommendations to quarantine and self isolate.
         <br/><br/>
-        Because people find it hard to stay at home alone, <a href="https://apnews.com/article/31e3e60e7ea6bc4566b0ee3998ab98a6">a lot of people decided to adopt a friend</a>.
+        Because people find it hard to stay at home alone, <a target="_blank" rel="noreferrer" href="https://apnews.com/article/31e3e60e7ea6bc4566b0ee3998ab98a6">a lot of people decided to adopt a friend</a>.
         <br/><br/>
         <b>Pawternity Hub wants to help you stay safe and help you find a friend that can keep you company during the pandemic<br/> Check out the links below for more information about adoption during Covid-19</b>
         <br/>

--- a/src/components/resources/Resources.js
+++ b/src/components/resources/Resources.js
@@ -12,13 +12,13 @@ export default function Home() {
         <br/><b>This leaves 1.8 million pets that go untouched each year.</b><br/><br/>
         Adopting a pet is cheaper than buying a pet, and you also potentially save a life by doing so. Many shelter pets are already house-trained and are used to living with humans.<br/><br/>
         <b>More information about adopting pets can be found at the links below</b><br/>
-        <Button href="https://www.petfinder.com/pet-adoption-2/pet-adoption-information/" variant="primary">
+        <Button href="https://www.petfinder.com/pet-adoption-2/pet-adoption-information/" target="_blank" variant="primary">
             Pet Finder
         </Button>
-        <Button href="https://www.humanesociety.org/resources/top-reasons-adopt-pet" variant="primary">
+        <Button href="https://www.humanesociety.org/resources/top-reasons-adopt-pet" target="_blank" variant="primary">
             Humane Society
         </Button>
-        <Button href="https://www.petcarehospital.net/blog/adopting-instead-of-buying-a-pet" variant="primary">
+        <Button href="https://www.petcarehospital.net/blog/adopting-instead-of-buying-a-pet" target="_blank" variant="primary">
             Petcare Hospital
         </Button>
       </p>
@@ -32,10 +32,10 @@ export default function Home() {
         <br/><br/>
         <b>Pawternity Hub wants to help you stay safe and help you find a friend that can keep you company during the pandemic<br/> Check out the links below for more information about adoption during Covid-19</b>
         <br/>
-        <Button href="https://www.petfinder.com/helping-pets/covid-19-resources/how-to-adopt-a-pet-during-covid-19/" variant="primary">
+        <Button href="https://www.petfinder.com/helping-pets/covid-19-resources/how-to-adopt-a-pet-during-covid-19/" target="_blank" variant="primary">
             Pet Finder (Adopting during Covid-19)
         </Button>
-        <Button href="https://www.oie.int/scientific-expertise/specific-information-and-recommendations/questions-and-answers-on-2019novel-coronavirus/" variant="primary">
+        <Button href="https://www.oie.int/scientific-expertise/specific-information-and-recommendations/questions-and-answers-on-2019novel-coronavirus/" target="_blank" variant="primary">
             World Organization for Animal Health
         </Button>
       </p>

--- a/src/components/resources/resources.css
+++ b/src/components/resources/resources.css
@@ -1,0 +1,7 @@
+.btn{
+margin:10px;
+}
+.resources__container{
+    text-align: center;
+    margin-top: 2rem;
+}

--- a/src/components/resources/resources.css
+++ b/src/components/resources/resources.css
@@ -1,7 +1,8 @@
-.btn{
-margin:10px;
-}
+
 .resources__container{
     text-align: center;
     margin-top: 2rem;
 }
+.resources__container .btn{
+    margin:10px;
+    }


### PR DESCRIPTION
Fixes #26

In this branch, I have implemented a resource page that the user read and get a better understanding of Adoption and why to choose it. I have also added links to external sites that talk about adoption including Pet finder (The websites API).

Secondly, I added a quick Covid-19 description and adoption during it, likewise with the other paragraph I added links to external sites that speak about adoption during the pandemic.

Lastly, I added a button that routes to /pets incase after reading this they want to adopt a pet.

I think some of this might also be helpful when we create the /about page for the website...

@redxzeta Let me know what you think and if I missed anything, also let me know if you would prefer me to use target="_blank". This would make it so that when the user clicks on the external link it would open a new tab instead of replacing the current tab (The website). Currently I don't have it targeted at anything but I think it might be better if we target it to blank so the user doesn't lose the website on their tabs list.