### PR TITLE
Added border around the contributors

### DIFF
--- a/src/components/about/about.css
+++ b/src/components/about/about.css
@@ -90,10 +90,5 @@
   border-radius: 100%;
 }
 
-.paragraph--section p {
-  text-align: left;
-}
-.paragraph--section a {
-  margin: 4.5px 0;
-  display: block;
-}
+.paragraph--section p {text-align: left;}
+.paragraph--section a {margin: 4.5px 0; display: block;}

--- a/src/components/about/about.css
+++ b/src/components/about/about.css
@@ -86,9 +86,14 @@
   animation-name: none;
   margin: 0 0.25rem !important;
   padding: 0;
-  border: 0 !important;
+  border: 2px solid red !important;
   border-radius: 100%;
 }
 
-.paragraph--section p {text-align: left;}
-.paragraph--section a {margin : 4.5px 0; display:block;}
+.paragraph--section p {
+  text-align: left;
+}
+.paragraph--section a {
+  margin: 4.5px 0;
+  display: block;
+}


### PR DESCRIPTION
About #84 
Added a red border around the contributors.
Here's what it looks like:
![Pawternity_Hub_-_2021-10-01_13 46 24](https://user-images.githubusercontent.com/80357251/135614917-8a19ee06-01a0-4f72-8c77-6d74f09460e8.png)
