### PR TITLE
fix github button background color after migration to bs5

### DIFF
--- a/src/components/about/about.css
+++ b/src/components/about/about.css
@@ -36,7 +36,7 @@
 .social-button {
   display: flex;
   align-items: center;
-  background: var(--primary);
+  background: var(--bs-primary);
   color: #fcfcfc;
   width: fit-content;
   border-radius: 0.25rem;


### PR DESCRIPTION
Fix background color
<img width="1280" alt="Screen Shot 2021-10-05 at 23 18 36" src="https://user-images.githubusercontent.com/9402714/136096503-dd7a738a-7c8e-4623-bf2b-c0719215d38b.png">
