### PR TITLE
fix pet card shrink

### DIFF
--- a/src/components/pets/PetType.js
+++ b/src/components/pets/PetType.js
@@ -193,7 +193,7 @@ export default function PetType({ token }) {
           <Button onClick={search}>GO</Button>
         </InputGroup>
       </div>
-      <Row>
+      <Row className="w-100">
         {loading ? (
           <LoadingSpinner />
         ) : (


### PR DESCRIPTION
Prevents pet card from shrinking (check image below) in case there are just two or one of them.

![image](https://user-images.githubusercontent.com/42191629/136802253-77629bd9-e353-4e6e-a752-23584597fa8a.png)
