### PR TITLE
Added fixes for PetType

### DIFF
--- a/src/components/pets/PetType.js
+++ b/src/components/pets/PetType.js
@@ -201,7 +201,6 @@ export default function PetType() {
             aria-describedby="inputGroup-sizing-sm"
             value={code}
             onChange={(e) => checkValidation(e)}
-            style={{ width: 150 }}
           />
           <Button disabled={goBtnDisabled} onClick={search}>
             Go

--- a/src/components/pets/pets.css
+++ b/src/components/pets/pets.css
@@ -42,6 +42,7 @@
 
 .inputContainer {
   flex: 1;
+  max-width: 340px;
 }
 
 .petList__container .card-img-top {
@@ -50,12 +51,29 @@
   align-self: center;
   border-radius: 4;
 }
+
 .petList__container .card {
-  width: 100%;
+  margin: 10px;
   padding-top: 10px;
   -webkit-box-shadow: 0px 10px 13px -7px #000000,
     5px 5px 15px 5px rgba(0, 0, 0, 0);
-  box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0, 0, 0, 0);
+  width: 20rem;
+  box-shadow: 5px 5px 13px -10px #000000, 5px 5px 15px 5px rgba(0, 0, 0, 0);
+}
+
+.petList__container .card__header {
+  background-color: #fff;
+}
+
+.petList__container .card-title {
+  text-align: center;
+  font-family: Amatic SC;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 28px;
+  line-height: 35px;
+
+  color: #000000;
 }
 
 .petList__container .petList {


### PR DESCRIPTION
#177 

Completed:
- Put go in the same line with zip code
![image](https://user-images.githubusercontent.com/90288516/138541161-aebde7b1-4a36-4ac0-8e2b-f3ad17a6667e.png)

Completed:
- In the local version, the card header uses bootstrap background color instead of #fff from
- bottom part of the card not using the same font from the home page
- apply the new box shadow same as the home page
![image](https://user-images.githubusercontent.com/90288516/138541205-9e4e5037-6d3f-48b4-9169-eaebef81327b.png)

Completed:
- clean up any unused css in pets.css

For the above, I tried not to leave in any unnecessary code in pets.css
