### PR TITLE
Adding a modal to edit profile information

### DIFF
--- a/src/components/accounts/profile/EditProfileModal.jsx
+++ b/src/components/accounts/profile/EditProfileModal.jsx
@@ -1,20 +1,34 @@
 import "./EditProfileModal.css";
-import { Button, Modal } from "react-bootstrap";
-
+import { Button, Modal, Form } from "react-bootstrap";
 export default function EditProfileModal({ show, handleClose }) {
+  const onSubmit = (e) => {
+    e.preventDefault();
+    console.log(e);
+    handleClose();
+  };
+
   return (
     <Modal show={show} onHide={handleClose} backdrop="static" keyboard={false}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>Edit Profile</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <p>Form here</p>
+        <Form>
+          <Form.Group className="mb-3" controlId="exampleForm.ControlInput1">
+            <Form.Label>Username</Form.Label>
+            <Form.Control type="text" />
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
+            <Form.Label>Description</Form.Label>
+            <Form.Control as="textarea" rows={3} />
+          </Form.Group>
+        </Form>
       </Modal.Body>
       <Modal.Footer>
-        <Button variant="secondary" onClick={handleClose}>
-          Cancel
+        <Button variant="secondary">Cancel</Button>
+        <Button variant="primary" onClick={onSubmit}>
+          Save
         </Button>
-        <Button variant="primary">Save</Button>
       </Modal.Footer>
     </Modal>
   );

--- a/src/components/accounts/profile/EditProfileModal.jsx
+++ b/src/components/accounts/profile/EditProfileModal.jsx
@@ -1,4 +1,3 @@
-import "./EditProfileModal.css";
 import { Button, Modal, Form } from "react-bootstrap";
 import { useState } from "react";
 
@@ -6,6 +5,11 @@ export default function EditProfileModal({ show, handleClose }) {
   const [username, setUsername] = useState("");
   const [description, setDescription] = useState("");
   const [usernameError, setUsernameError] = useState("");
+  const [savedProfile, setSavedProfile] = useState({});
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  const handleCloseConfirmation = () => setShowConfirmation(false);
+  const handleShowConfirmation = () => setShowConfirmation(true);
 
   const onSubmit = (e) => {
     e.preventDefault();
@@ -13,13 +17,27 @@ export default function EditProfileModal({ show, handleClose }) {
     if (!username || username === "") {
       setUsernameError("Username cannot be blank!");
     } else {
-      // No errors
-      console.log("Passed validation!", {
+      // No errors:
+      const newProfile = {
         username: username,
         description: description,
-      });
+      };
+
+      setSavedProfile(newProfile);
+      console.log("Passed validation! Profile: ", newProfile);
       handleClose();
     }
+  };
+
+  const onConfirmedExit = (e) => {
+    e.preventDefault();
+
+    // Revert any changes made to profile
+    setUsername(savedProfile.username || "");
+    setDescription(savedProfile.description || "");
+
+    handleCloseConfirmation();
+    handleClose();
   };
 
   return (
@@ -56,7 +74,29 @@ export default function EditProfileModal({ show, handleClose }) {
         </Form>
       </Modal.Body>
       <Modal.Footer>
-        <Button variant="secondary">Cancel</Button>
+        <Button variant="secondary" onClick={handleShowConfirmation}>
+          Cancel
+        </Button>
+        <Modal
+          show={showConfirmation}
+          onHide={handleCloseConfirmation}
+          backdrop="static"
+          keyboard={false}
+          centered
+          size="sm"
+        >
+          <Modal.Header>
+            <Modal.Title>Exit Editing?</Modal.Title>
+          </Modal.Header>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={handleCloseConfirmation}>
+              Back
+            </Button>
+            <Button variant="dark" onClick={onConfirmedExit}>
+              Confirm Exit
+            </Button>
+          </Modal.Footer>
+        </Modal>
         <Button variant="primary" onClick={onSubmit}>
           Save
         </Button>

--- a/src/components/accounts/profile/EditProfileModal.jsx
+++ b/src/components/accounts/profile/EditProfileModal.jsx
@@ -1,0 +1,21 @@
+import "./EditProfileModal.css";
+import { Button, Modal } from "react-bootstrap";
+
+export default function EditProfileModal({ show, handleClose }) {
+  return (
+    <Modal show={show} onHide={handleClose} backdrop="static" keyboard={false}>
+      <Modal.Header closeButton>
+        <Modal.Title>Edit Profile</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>Form here</p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button variant="primary">Save</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/accounts/profile/EditProfileModal.jsx
+++ b/src/components/accounts/profile/EditProfileModal.jsx
@@ -1,10 +1,25 @@
 import "./EditProfileModal.css";
 import { Button, Modal, Form } from "react-bootstrap";
+import { useState } from "react";
+
 export default function EditProfileModal({ show, handleClose }) {
+  const [username, setUsername] = useState("");
+  const [description, setDescription] = useState("");
+  const [usernameError, setUsernameError] = useState("");
+
   const onSubmit = (e) => {
     e.preventDefault();
-    console.log(e);
-    handleClose();
+
+    if (!username || username === "") {
+      setUsernameError("Username cannot be blank!");
+    } else {
+      // No errors
+      console.log("Passed validation!", {
+        username: username,
+        description: description,
+      });
+      handleClose();
+    }
   };
 
   return (
@@ -16,11 +31,27 @@ export default function EditProfileModal({ show, handleClose }) {
         <Form>
           <Form.Group className="mb-3" controlId="exampleForm.ControlInput1">
             <Form.Label>Username</Form.Label>
-            <Form.Control type="text" />
+            <Form.Control
+              type="text"
+              value={username}
+              onChange={(e) => {
+                setUsername(e.target.value);
+                setUsernameError("");
+              }}
+              isInvalid={!!usernameError}
+            />
+            <Form.Control.Feedback type="invalid">
+              {usernameError}
+            </Form.Control.Feedback>
           </Form.Group>
           <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
             <Form.Label>Description</Form.Label>
-            <Form.Control as="textarea" rows={3} />
+            <Form.Control
+              as="textarea"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
           </Form.Group>
         </Form>
       </Modal.Body>

--- a/src/components/accounts/profile/Profile.jsx
+++ b/src/components/accounts/profile/Profile.jsx
@@ -3,8 +3,9 @@ import { Image, Container, Row, Col, Button } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { useFilter, useSelect } from "react-supabase";
 import { useState } from "react";
-import "./profile.css";
 import EditProfileModal from "./EditProfileModal";
+
+import "./profile.css";
 
 const sampleUsername = "jjVYG46RTL1BpOOaTYuU";
 const Profile = () => {

--- a/src/components/accounts/profile/Profile.jsx
+++ b/src/components/accounts/profile/Profile.jsx
@@ -2,7 +2,10 @@
 import { Image, Container, Row, Col, Button } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { useFilter, useSelect } from "react-supabase";
+import { useState } from "react";
 import "./profile.css";
+import EditProfileModal from "./EditProfileModal";
+
 const sampleUsername = "jjVYG46RTL1BpOOaTYuU";
 const Profile = () => {
   // const [userName, setUserName] = useState(sampleUsername);
@@ -14,6 +17,9 @@ const Profile = () => {
   const [{ data, fetching }] = useSelect("profiles", {
     filter,
   });
+  const [showModal, setShow] = useState(false);
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
 
   let x = "";
   if (fetching) {
@@ -49,6 +55,15 @@ const Profile = () => {
       {x}
 
       {data && data.username}
+
+      <Button variant="primary" onClick={handleShow}>
+        Edit
+      </Button>
+
+      <EditProfileModal
+        show={showModal}
+        handleClose={handleClose}
+      ></EditProfileModal>
 
       <Link to="">
         <Button className="mt-5 px-5" variant="primary">


### PR DESCRIPTION
## Description
Fixes #207. Users can now update their username and description through a modal.

## Changes:
- Added `src/components/accounts/profile/EditProfileModal.jsx` to render the Modal in `src/components/accounts/profile/Profile.jsx`
- Added a button in the `Profile` view that opens up a modal
- Modal contains a form to edit username and description
- Username is validated, cannot be empty
- `Save` button saves the changes (after validation)
- `Cancel` button prompts the user with a warning through a confirmation dialog box
- `Confirm Exit` discards any changes made to the profile

## Screenshots
![image](https://user-images.githubusercontent.com/52294825/139571189-adb46d73-a64a-4977-adbb-627e8c42690f.png)
![image](https://user-images.githubusercontent.com/52294825/139571159-4ee4147a-b32b-40a0-b8c8-89bc29b42f3c.png)
![image](https://user-images.githubusercontent.com/52294825/139571286-6060de42-87ce-429f-89eb-eaf941d6748a.png)