### PR TITLE
Adding tests for login and register

### DIFF
--- a/src/components/accounts/Register.jsx
+++ b/src/components/accounts/Register.jsx
@@ -24,7 +24,9 @@ const Register = () => {
     onClickSignUp();
   };
   const errorForm = error ? (
-    <small className="text-danger">{error.message}</small>
+    <small className="text-danger" test-id="formErrorMessage">
+      {error.message}
+    </small>
   ) : (
     ""
   );

--- a/src/components/accounts/__tests__/Register.test.js
+++ b/src/components/accounts/__tests__/Register.test.js
@@ -1,0 +1,27 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
+import { Provider } from "react-supabase";
+import { supabase } from "../../../utils/SupaBaseUtils";
+
+import Register from "../Register";
+
+test("should register sucessfully", async () => {
+  const { getByLabelText, getByText } = render(
+    <Provider value={supabase}>
+      <Register />
+    </Provider>
+  );
+
+  fireEvent.change(getByLabelText(/email/i), {
+    target: { value: "fake_acc_id" },
+  });
+  fireEvent.change(getByLabelText(/password/i), {
+    target: { value: "fake_password" },
+  });
+
+  fireEvent.click(getByText(/submit/i));
+
+  await waitFor(() => {
+    expect(screen.getByText(/Success/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/accounts/__tests__/Register.test.js
+++ b/src/components/accounts/__tests__/Register.test.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import React from "react";
 import { Provider } from "react-supabase";
-import { supabase } from "../../../utils/SupaBaseUtils";
+import { supabase } from "../../../testServer";
 
 import Register from "../Register";
 

--- a/src/components/accounts/__tests__/SLogin.test.js
+++ b/src/components/accounts/__tests__/SLogin.test.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import React from "react";
 import { Provider } from "react-supabase";
-import { supabase } from "../../../utils/SupaBaseUtils";
+import { supabase } from "../../../testServer";
 
 import SLogin from "../SLogin";
 

--- a/src/components/accounts/__tests__/SLogin.test.js
+++ b/src/components/accounts/__tests__/SLogin.test.js
@@ -1,0 +1,44 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
+import { Provider } from "react-supabase";
+import { supabase } from "../../../utils/SupaBaseUtils";
+
+import SLogin from "../SLogin";
+
+test("should show error message for empty fields", async () => {
+  const { getByText } = render(
+    <Provider value={supabase}>
+      <SLogin />
+    </Provider>
+  );
+
+  fireEvent.click(getByText(/submit/i));
+
+  await waitFor(() => {
+    expect(
+      screen.getByText(
+        /You must provide either an email, phone number or a third-party provider/i
+      )
+    ).toBeInTheDocument();
+  });
+});
+
+test("should show error message for incorrect email format", async () => {
+  const { getByLabelText, getByText } = render(
+    <Provider value={supabase}>
+      <SLogin />
+    </Provider>
+  );
+
+  fireEvent.change(getByLabelText(/email/i), {
+    target: { value: "incorrect_format" },
+  });
+
+  fireEvent.click(getByText(/submit/i));
+
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Unable to validate email address: invalid format/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -25,11 +25,43 @@ const server = setupServer(
   ),
   rest.get("https://api.petfinder.com/v2/animals", (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(contributors));
-  })
+  }),
+  //Login
+  rest.post(
+    "https://vuxohlizzevgcsxlrggf.supabase.co/auth/v1/token",
+    (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json({ access_token: "fake_access_token" })
+      );
+    }
+  ),
+  //Register
+  rest.post(
+    "https://vuxohlizzevgcsxlrggf.supabase.co/auth/v1/signup",
+    (req, res, ctx) => {
+      const fake_new_account = {
+        id: "fake_acc_id",
+        aud: "authenticated",
+        role: "authenticated",
+        email: "fake_acc_id@test.com",
+        phone: "",
+        confirmation_sent_at: Date.now(),
+        app_metadata: { provider: "email", providers: ["email"] },
+        user_metadata: {},
+        identities: [],
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      };
+      return res(ctx.status(200), ctx.json(fake_new_account));
+    }
+  )
 );
 
 beforeAll(() => server.listen());
 afterAll(() => server.close());
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+});
 
 export { server, rest };

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -28,35 +28,35 @@ const server = setupServer(
     return res(ctx.status(200), ctx.json(contributors));
   }),
   //Login
-  rest.post(
-    "https://vuxohlizzevgcsxlrggf.supabase.co/auth/v1/token",
-    (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json({ access_token: "fake_access_token" })
-      );
-    }
-  ),
+  rest.post("https://test.supabase.co/auth/v1/token", (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({ access_token: "fake_access_token" })
+    );
+  }),
+  rest.post("https://test.supabase.co/auth/v1/magicLink", (req, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({ message: "Unable to validate email address: invalid format" })
+    );
+  }),
   //Register
-  rest.post(
-    "https://vuxohlizzevgcsxlrggf.supabase.co/auth/v1/signup",
-    (req, res, ctx) => {
-      const fake_new_account = {
-        id: "fake_acc_id",
-        aud: "authenticated",
-        role: "authenticated",
-        email: "fake_acc_id@test.com",
-        phone: "",
-        confirmation_sent_at: Date.now(),
-        app_metadata: { provider: "email", providers: ["email"] },
-        user_metadata: {},
-        identities: [],
-        created_at: Date.now(),
-        updated_at: Date.now(),
-      };
-      return res(ctx.status(200), ctx.json(fake_new_account));
-    }
-  )
+  rest.post("https://test.supabase.co/auth/v1/signup", (req, res, ctx) => {
+    const fake_new_account = {
+      id: "fake_acc_id",
+      aud: "authenticated",
+      role: "authenticated",
+      email: "fake_acc_id@test.com",
+      phone: "",
+      confirmation_sent_at: Date.now(),
+      app_metadata: { provider: "email", providers: ["email"] },
+      user_metadata: {},
+      identities: [],
+      created_at: Date.now(),
+      updated_at: Date.now(),
+    };
+    return res(ctx.status(200), ctx.json(fake_new_account));
+  })
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
@@ -65,9 +65,8 @@ afterEach(() => {
   server.resetHandlers();
 });
 
-const SUPABASE_URL = "https://vuxohlizzevgcsxlrggf.supabase.co";
-const KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYzMzg4NzYwNCwiZXhwIjoxOTQ5NDYzNjA0fQ.fxjuENwSq1mulGqA4OOnrbcZu-sW3EVVfHNQjOU0vOs";
+const SUPABASE_URL = "https://test.supabase.co";
+const KEY = "test";
 const supabase = createClient(SUPABASE_URL, KEY);
 
 export { server, rest, supabase };

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -1,6 +1,7 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import PlaceImage from "./components/about/__tests__/placeholder50px.png";
+import { createClient } from "@supabase/supabase-js";
 import { githubURL } from "./routes/API";
 const contributors = [
   {
@@ -58,10 +59,15 @@ const server = setupServer(
   )
 );
 
-beforeAll(() => server.listen());
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
 afterAll(() => server.close());
 afterEach(() => {
   server.resetHandlers();
 });
 
-export { server, rest };
+const SUPABASE_URL = "https://vuxohlizzevgcsxlrggf.supabase.co";
+const KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYzMzg4NzYwNCwiZXhwIjoxOTQ5NDYzNjA0fQ.fxjuENwSq1mulGqA4OOnrbcZu-sW3EVVfHNQjOU0vOs";
+const supabase = createClient(SUPABASE_URL, KEY);
+
+export { server, rest, supabase };


### PR DESCRIPTION
Added tests for the following:
- `src/components/SLogin`
- `src/components/Register`

For mocking the requests, I used the already existing `src/testServer.js` module to handle the `login` and `signup` requests.

The tests can be found in:
```
src/components/accounts/__tests__/SLogin.test.js
src/components/accounts/__tests__/Register.test.js
```
![image](https://user-images.githubusercontent.com/52294825/142363164-e58bd09d-804e-4ff3-a5c8-68c3f313cdd1.png)
