### PR TITLE
Handle Long Petinfo Email

### DIFF
--- a/src/components/pets/PetInfo.css
+++ b/src/components/pets/PetInfo.css
@@ -44,3 +44,7 @@
   margin: 8px 4px;
   width: 15rem;
 }
+
+.contact {
+  word-wrap: break-word;
+}

--- a/src/components/pets/PetInfo.js
+++ b/src/components/pets/PetInfo.js
@@ -110,7 +110,7 @@ export default function PetInfo() {
         <div className="contact-info">
           <HiMail className="icon" />
           <Card.Title>Contact</Card.Title>
-          <Card.Text>
+          <Card.Text className="contact">
             <a
               href={`mailto:${pet.contact && pet.contact.email}`}
               target="_blank"


### PR DESCRIPTION
Hello, this is my solution of issue #255  to handle some emails of `petInfo` that could get too long. I "break" the words, so that it will not go over the box border.

This is an example:
![pet info email](https://user-images.githubusercontent.com/69607880/146212540-1c7c1779-30c0-4c87-a86e-2a8b8d14c085.png)
