### PR TITLE
feat: Add tooltips to about page contributors

### DIFF
--- a/src/components/about/Contributors.tsx
+++ b/src/components/about/Contributors.tsx
@@ -1,4 +1,5 @@
 import Spinner from "components/shared/spinner/Spinner";
+import { Tooltip } from "react-daisyui";
 import useSWR from "swr";
 
 import { githubURL } from "../../routes/API";
@@ -50,11 +51,13 @@ const Contributors = () => {
           rel="noreferrer"
           data-testid="contributor-list"
         >
-          <img
-            className="w-12 mx-1 border-primary border-2 rounded-full"
-            src={a.avatar_url}
-            alt={`${a.login} Contributor Avatar`}
-          />
+          <Tooltip message={a.login}>
+            <img
+              className="w-12 mx-1 border-primary border-2 rounded-full"
+              src={a.avatar_url}
+              alt={`${a.login} Contributor Avatar`}
+            />
+          </Tooltip>
         </a>
       ))}
     </div>


### PR DESCRIPTION
https://github.com/redxzeta/Awesome-Adoption/issues/349

* Add Tooltips to contributor page using `react-daisyui`


Preview:
![image](https://user-images.githubusercontent.com/7072946/184725492-203729d2-4def-4cde-a5eb-5479982cfc91.png)
