### PR TITLE
fix: make organization cards even

### DIFF
--- a/src/components/organizations/OrganizationsCard.tsx
+++ b/src/components/organizations/OrganizationsCard.tsx
@@ -3,13 +3,15 @@ import { Card } from "react-daisyui";
 import { CharityType } from "./Organizations";
 
 const DonateCard = ({ ch }: { ch: CharityType }) => (
-  <article className="lg:px-4 px-1 w-full md:1/3 lg:w-1/4 my-4 fadeInUp ">
-    <Card imageFull>
+  <article className="lg:px-4 px-1 w-full md:1/3 lg:w-1/4 my-4 fadeInUp flex">
+    <Card imageFull className="w-full">
       <Card.Image src={ch.logo} alt={ch.name} className="w-full max-h-80 " />
       <Card.Body>
         <Card.Title tag="h2">{ch.name}</Card.Title>
-        <p>Location: {ch.location}</p>
-        <p>Founded: {ch.founded}</p>
+        <p>
+          Location: {ch.location} <br />
+          Founded: {ch.founded}
+        </p>
         <Card.Actions className="justify-end">
           <a
             href={ch.website}

--- a/src/components/organizations/__tests__/organizations.test.tsx
+++ b/src/components/organizations/__tests__/organizations.test.tsx
@@ -38,7 +38,7 @@ describe("Organizations", () => {
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryAllByText(/^Location: United States$/i).length
+      screen.queryAllByText(/^Location: United States /i).length
     ).toBeGreaterThan(0);
 
     expect(


### PR DESCRIPTION
### What's in this PR?
Make the organization cards are now even to fix issue #430

### Completed

Use `display: flex` to get the cards to autofill the blank space, and use only one `<p>` tag in the card body for better alignment of the text.

<img width="1316" alt="Screenshot 2022-10-03 at 11 18 06 AM" src="https://user-images.githubusercontent.com/8704966/193507181-59eb6224-947f-4a83-b3db-c97a68e83c00.png">


