### PR TITLE
fix: hiding the hamburger menu navigation on lg screens

### DIFF
--- a/src/components/layout/NavigationBar.tsx
+++ b/src/components/layout/NavigationBar.tsx
@@ -22,7 +22,7 @@ export default function NavigationBar() {
             <Button color="ghost" tabIndex={0} className="lg:hidden">
               <Bars3BottomLeftIcon className="w-5 h-5" />
             </Button>
-            <Dropdown.Menu className="w-52 menu-compact mt-3 ">
+            <Dropdown.Menu className="w-52 menu-compact mt-3 lg:hidden">
               <DropdownNavLink route="/">Home</DropdownNavLink>
               <li tabIndex={0}>
                 <a className="justify-between">


### PR DESCRIPTION
fixes: https://github.com/redxzeta/Awesome-Adoption/issues/484

|Before|After|
|-------|-----|
|![ezgif-4-beb5b107af](https://user-images.githubusercontent.com/40167428/195015644-a67330d2-a308-4c93-903b-30442c2d1865.gif)| ![fix](https://user-images.githubusercontent.com/40167428/195039352-f83d568d-030f-4175-9348-2c089bc64fac.gif)|