### PR TITLE
[Fixed] : footer always in bottom

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,6 +6,14 @@
   -webkit-animation-fill-mode: both;
   animation-fill-mode: both;
 }
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.container {
+  flex: 1;
+}
 @-webkit-keyframes fadeInUp {
   0% {
     opacity: 0;


### PR DESCRIPTION
Issue #454 

## kindly review it. @redxzeta 
I made the root which is acting as a container as a flexbox and given a height of 100vh, and then make the content flex-1 to take up the whole available space in viewport, So it automatically pushes the footer bottom of the page.

<img width="1440" alt="Screenshot 2022-10-15 at 7 59 03 AM" src="https://user-images.githubusercontent.com/95350799/195965511-eb0a55fc-3fd7-4f4d-b04d-ee9752d46b95.png">

<img width="1440" alt="Screenshot 2022-10-15 at 7 58 55 AM" src="https://user-images.githubusercontent.com/95350799/195965522-ad9aaf84-985e-47dc-82c8-4779499b0497.png">
