### PR TITLE
fix: image sizes in the carousel is not equal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,14 @@
 .container {
   flex: 1;
 }
+
+.carousel img {
+  object-fit: cover;
+  object-position: center;
+  height: 80vh;
+  overflow: hidden;
+}
+
 @-webkit-keyframes fadeInUp {
   0% {
     opacity: 0;


### PR DESCRIPTION
#### Description 
Fixed the unequal image sizes in the carousel : issue #486 

#### Issue
The height of carousel was setting with the highest image, thus resulting in unequal images and leaving the round bottom of carousel at bottom

#### Summary
1. Changed the carousel css to incorporate equal images at PetInfo page.
2. Used height as **80vh** just to make it elegant. 
#### Screenshots
<img width="1484" alt="image" src="https://user-images.githubusercontent.com/42544589/196458193-04ddf168-a221-4795-b4a2-b2f2e1ff2041.png">
<img width="1551" alt="image" src="https://user-images.githubusercontent.com/42544589/196458288-0c69b625-821e-4568-a3d7-f400bd3350d5.png">
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/42544589/196458372-d70ef59a-cd0b-4bdf-b406-b49498e445ec.png">
<img width="1518" alt="image" src="https://user-images.githubusercontent.com/42544589/196458474-bfef59fa-9196-4448-a1e1-a612aa86ca83.png">

 