### PR TITLE
fix: zipcode label overflowing

### DIFF
--- a/src/components/pets/PetType.tsx
+++ b/src/components/pets/PetType.tsx
@@ -213,7 +213,7 @@ export default function PetType() {
         List Of {type} Buddies
       </h1>
       <div className="w-full flex justify-center items-center flex-col lg:p-4 my-2">
-        <Form className="shadow   rounded-lg p-4  lg:w-1/4 w-full">
+        <Form className="shadow rounded-lg p-4 lg:w-1/4 w-full">
           <Form.Label title="Enter Zipcode: ">
             <Input
               ref={inputCode}
@@ -224,6 +224,7 @@ export default function PetType() {
               value={code}
               name="zipcode"
               onChange={checkValidation}
+              className="lg:w-full w-1/2"
             />
           </Form.Label>
           <Button


### PR DESCRIPTION
Fixes #499 

|Before|After|
|-|-|
|<img width="441" alt="Screenshot 2022-10-20 at 6 01 51 PM" src="https://user-images.githubusercontent.com/25058106/197276941-cee6e530-f5a0-4764-a761-efa7bb51f7ce.png">|<img width="374" alt="Screenshot 2022-10-22 at 1 09 35 AM" src="https://user-images.githubusercontent.com/25058106/197276946-a37c5193-226c-4220-a310-026da25d3706.png">|
